### PR TITLE
Fix GraalVM docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Running the native image only with --help/--version returns the help message/ver
 
 **Prerequisites**
 
-- Install graalvm (https://www.graalvm.org/getting-started/)
+- Install graalvm (https://www.graalvm.org/docs/getting-started/)
 - Install native-image extension of graalvm
 - Install maven (https://maven.apache.org/install.html)
 


### PR DESCRIPTION
The previous URL still served a page, but that was broken and resulted in white text on white background.